### PR TITLE
Improve receiver_fields selection

### DIFF
--- a/frappe_threema/threema/doctype/notification/notification.js
+++ b/frappe_threema/threema/doctype/notification/notification.js
@@ -28,9 +28,7 @@ frappe.notification = {
                 // to find additional fields
                 let is_receiver_field = function (df) {
                     return (
-                        is_extra_receiver_field(df) ||
-                        (df.options == "User" && df.fieldtype == "Link") ||
-                        (df.options == "Customer" && df.fieldtype == "Link")
+                        is_extra_receiver_field(df)
                     );
                 };
                 let extract_receiver_field = function (df) {
@@ -53,7 +51,7 @@ frappe.notification = {
 
             if (["Threema"].includes(frm.doc.channel)) {
                 const receiver_fields = get_receiver_fields(fields, function (df) {
-                    df.options == "Threema" || df.options == "Phone" || df.options == "Mobile";
+                    return df.options === "Phone";
                 });
                 frm.fields_dict.recipients.grid.update_docfield_property(
                     "receiver_by_document_field",


### PR DESCRIPTION
The field option is used to check that only fields containing a phone number are displayed in the receiver_fields selection. All other fields are no longer included in the selection.