### PR TITLE
chore: Automerge prettier updates via Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": ["config:recommended"],
+  "packageRules": [
+    {
+      "description": "Automerge prettier updates when CI is green",
+      "matchPackageNames": ["prettier"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
Adds a Renovate packageRule that automerges prettier minor/patch updates once all required status checks pass. Majors are excluded since they change formatting output and need a manual reformat commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)